### PR TITLE
Add image pushing to circleci config to gcp eliot prod artifact registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ orbs:
 
 jobs:
   main:
-    machine:
-      image: ubuntu-2004:202201-02
+    docker:
+      - image: cimg/base:2022.06
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ orbs:
 
 jobs:
   main:
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,25 @@
 ---
-# These environment variables must be set in CircleCI UI
+# Will use circleci mozilla-services context: eliot-circleci-image-push
 #
-# DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
-# DOCKER_USER    - login info for docker hub
-# DOCKER_PASS
+
 version: 2.1
+
+# See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
+orbs:
+  gcp-gcr: circleci/gcp-gcr@0.15.0
+
 jobs:
   main:
-    docker:
-      - image: cimg/python:3.11.1
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-
     steps:
       - checkout
-
       - setup_remote_docker:
           docker_layer_caching: true
           version: 20.10.18
-
       - run:
           name: Get info
           command: |
             uname -v
             docker info
-
-      - run:
-          name: Login to Dockerhub
-          # yamllint disable rule:line-length
-          command: |
-            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-              echo "Skipping Login to Dockerhub, credentials not available."
-            else
-              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-            fi
-          # yamllint enable rule:line-length
-
       - run:
           name: Create version.json
           # yamllint disable rule:line-length
@@ -50,49 +33,53 @@ jobs:
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
           # yamllint enable rule:line-length
-
       - run:
           name: Build Docker images
           command: |
-            # build tecken containers
             make build
-
       - run:
           name: Verify requirements.txt contains correct dependencies
           # yamllint disable rule:line-length
           command: |
             docker compose run --rm --no-deps test-ci bash ./bin/run_verify_reqs.sh
           # yamllint enable rule:line-length
-
       - run:
           name: Run lint check
           command: |
             make .env
             docker compose run --rm --no-deps test-ci bash ./bin/run_lint.sh
-
       - run:
           name: Run Eliot tests
           command: |
             make .env
             docker compose up -d fakesentry statsd
             docker compose run --rm test-ci bash ./bin/run_test.sh eliot
-
       - run:
           name: Build docs
           command: |
             make .env
             docker compose run --rm --no-deps test-ci bash make -C docs/ html
 
-      - run:
-          name: Push to Dockerhub
-          command: |
-            bin/circleci_push.sh "eliot:build"
 
 workflows:
   version: 2
-  build-test-push:
+  build_and_test:
     jobs:
       - main:
           filters:
             tags:
               only: /.*/
+
+  deploy_eliot_image:
+    jobs:
+      - gcp-gcr/build-and-push-image:
+          name: Build and push image for eliot
+          context: eliot-circleci-image-push
+          registry-url: us-docker.pkg.dev
+          image: eliot-prod/eliot
+          tag: ${CIRCLE_TAG:-latest}
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master


### PR DESCRIPTION
Note: This will fail until I am able to provision the service account credentials in GCP and add them to the circleci context.