### PR TITLE
bug 1824013: fix honcho logging

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -21,7 +21,7 @@ shift
 
 case ${SERVICE} in
 eliot)  ## Run Eliot service
-    exec honcho -f /app/Procfile start
+    exec honcho -f /app/Procfile --no-prefix start
     ;;
 bash)  ## Open a bash shell or run something else
     if [ -z "$*" ]; then

--- a/eliot/cache_manager.py
+++ b/eliot/cache_manager.py
@@ -156,7 +156,7 @@ class DiskCacheManager:
         setup_logging(
             logging_level=self.config("logging_level"),
             debug=self.config("local_dev_env"),
-            processname="cache_manager",
+            processname="disk_manager",
         )
         setup_metrics(
             statsd_host=self.config("statsd_host"),


### PR DESCRIPTION
This removes the Honcho prefix from the logging output which particularly messed up the mozlog format.