### PR TITLE
bug 1825133: downgrade datadog to 0.44.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@ backoff==2.2.1
 black==23.1.0
 boltons==23.0.0
 click==8.1.3
-datadog==0.45.0
 dockerflow==2022.8.0
 everett==3.2.0
 falcon==3.1.1
@@ -25,3 +24,6 @@ sphinx-rtd-theme==1.0.0
 symbolic==10.2.1
 urllib3==1.26.14
 werkzeug==2.2.3
+
+# bug 1825133: downgrade so it doesn't emit container id
+datadog==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,9 +127,9 @@ click==8.1.3 \
     #   -r requirements.in
     #   black
     #   pip-tools
-datadog==0.45.0 \
-    --hash=sha256:144fce48bda79484b102349f159c4ea4c7cd35361f9e0d031ddf931a922a38a4 \
-    --hash=sha256:6bffed67448cb4bf5dff559fb2acee1c06e7da8612b8e2a734f278b50b396603
+datadog==0.44.0 \
+    --hash=sha256:071170f0c7ef22511dbf7f9bd76c4be500ee2d3d52072900a5c87b5495d2c733 \
+    --hash=sha256:57c4878d3a8351f652792cdba78050274789dcc44313adec096e87f9d3ca5992
     # via
     #   -r requirements.in
     #   markus


### PR DESCRIPTION
This downgrades the datadog library to 0.44.0 which is before they added support for the datadog protocol v1.2 with the container id which telegraf doesn't seem to like.