### PR TITLE
bug 1825133: update to markus 4.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ gunicorn==20.1.0
 honcho==1.1.0
 inotify_simple==1.3.5
 jsonschema==4.17.3
-markus[datadog]==4.1.0
+markus[datadog]==4.2.0
 msgpack==1.0.5
 pip-tools==6.12.3
 pytest==7.2.2
@@ -24,6 +24,3 @@ sphinx-rtd-theme==1.0.0
 symbolic==10.2.1
 urllib3==1.26.14
 werkzeug==2.2.3
-
-# bug 1825133: downgrade so it doesn't emit container id
-datadog==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,12 +127,10 @@ click==8.1.3 \
     #   -r requirements.in
     #   black
     #   pip-tools
-datadog==0.44.0 \
-    --hash=sha256:071170f0c7ef22511dbf7f9bd76c4be500ee2d3d52072900a5c87b5495d2c733 \
-    --hash=sha256:57c4878d3a8351f652792cdba78050274789dcc44313adec096e87f9d3ca5992
-    # via
-    #   -r requirements.in
-    #   markus
+datadog==0.45.0 \
+    --hash=sha256:144fce48bda79484b102349f159c4ea4c7cd35361f9e0d031ddf931a922a38a4 \
+    --hash=sha256:6bffed67448cb4bf5dff559fb2acee1c06e7da8612b8e2a734f278b50b396603
+    # via markus
 dockerflow==2022.8.0 \
     --hash=sha256:cebd5e12ff08be43b02ea4fcaf044fb2cd4cec63c93dbfbe6e3c5b610849924c \
     --hash=sha256:fcb95ea8226551e1fd03c3c82f2b11de50434ddfa63cebc164399dabf5c78908
@@ -272,9 +270,9 @@ markupsafe==2.1.1 \
     # via
     #   jinja2
     #   werkzeug
-markus[datadog]==4.1.0 \
-    --hash=sha256:47d61c0208579a4ade63fdde5ed4e2245728f359f3f9873506c41d7d2590474e \
-    --hash=sha256:9913541cbea8fd311ce1feee406763a1bef91c611d41c57db8139d1198948b84
+markus[datadog]==4.2.0 \
+    --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \
+    --hash=sha256:9dd41ce53b25a3e806b0d065808fec00c4ec945e80cf5a72431bf9b61b44d7fb
     # via -r requirements.in
 mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \


### PR DESCRIPTION
This updates to Markus 4.2.0 which requires datadog >= 0.45.0 and sets origin_detection_enabled to False when building the DogStatsD client so the DogStatsD doesn't emit the container id which telegraf can't parse.