### PR TITLE
Update dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ click==8.1.3
 dockerflow==2022.8.0
 everett==3.2.0
 falcon==3.1.1
-fillmore==1.0.0
+fillmore==1.1.0
 flake8==6.0.0
 gunicorn==20.1.0
 honcho==1.1.0
@@ -17,7 +17,7 @@ pip-tools==6.12.3
 pytest==7.2.2
 requests==2.28.2
 requests-mock==1.10.0
-sentry-sdk==1.12.1
+sentry-sdk==1.19.1
 Sphinx==5.1.1
 sphinxcontrib-httpdomain==1.8.1
 sphinx-rtd-theme==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,9 +183,9 @@ falcon==3.1.1 \
     --hash=sha256:fd1eaf1a5d9d936f29f9aca3f268cf375621d1ffcbf27a6e14c187b489bf5f26 \
     --hash=sha256:ff2eaf9807ea357ced1cc60e1d2871f55aa6ea29162386efb95fb4e5a730e6de
     # via -r requirements.in
-fillmore==1.0.0 \
-    --hash=sha256:6829367ad75f10711a9b97144cb3f9a925d0c06af9c460ea28ab51f8a6d5cd80 \
-    --hash=sha256:9a7f5e3f559ee19307110e8ef094e3063cae666e698a7fe679b959e3c5eaebd4
+fillmore==1.1.0 \
+    --hash=sha256:68b2aa27340725026d7be1e4e96c3ec3ef954f66410e1cb65d0d85a692f0fdc1 \
+    --hash=sha256:8afe5fa0f59d99bc10f2996d23755860dd8b8f1aebe96c34fd5d0e5e1c2e0771
     # via -r requirements.in
 flake8==6.0.0 \
     --hash=sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7 \
@@ -438,9 +438,9 @@ requests-mock==1.10.0 \
     --hash=sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699 \
     --hash=sha256:59c9c32419a9fb1ae83ec242d98e889c45bd7d7a65d48375cc243ec08441658b
     # via -r requirements.in
-sentry-sdk==1.12.1 \
-    --hash=sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c \
-    --hash=sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6
+sentry-sdk==1.19.1 \
+    --hash=sha256:7ae78bd921981a5010ab540d6bdf3b793659a4db8cccf7f16180702d48a80d84 \
+    --hash=sha256:885a11c69df23e53eb281d003b9ff15a5bdfa43d8a2a53589be52104a1b4582f
     # via
     #   -r requirements.in
     #   fillmore

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 from unittest.mock import ANY
 
+from fillmore.test import diff_event
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -172,11 +172,8 @@ def test_sentry_scrubbing(sentry_helper):
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        # If this test fails, this will print out the new event that you can copy and
-        # paste and then edit above
-        print(json.dumps(event, indent=4, sort_keys=True))
-
-        assert event == BROKEN_EVENT
+        differences = diff_event(event, BROKEN_EVENT)
+        assert differences == []
 
 
 def test_count_sentry_scrub_error():


### PR DESCRIPTION
* fillmore: 1.0.0 -> 1.1.0
* sentry-sdk: 1.12.1 -> 1.19.1

This also changes how we verify Sentry scrubbing to use `fillmore.test.diff_event`.