### PR TITLE
bug 1828542: fix debug stats timings for symbolication

### DIFF
--- a/tests/test_symbolicate_resource.py
+++ b/tests/test_symbolicate_resource.py
@@ -428,6 +428,16 @@ class TestSymbolicateBase:
                     "testproj/D48F191186D67E69DF025AD71FB91E1F0": ANY,
                 },
             },
+            "parse_sym": {
+                "time_per_module": {
+                    "testproj/D48F191186D67E69DF025AD71FB91E1F0": ANY,
+                },
+            },
+            "save_symcache": {
+                "time_per_module": {
+                    "testproj/D48F191186D67E69DF025AD71FB91E1F0": ANY,
+                },
+            },
         }
 
     def test_symbolicate_pe_file(self, requestsmock, tmpcachedir, tmpdir):


### PR DESCRIPTION
This breaks up the "downloads" timing into "downloads", "parse_sym", and "save_symcache" which gives us a much better idea of where time is going.

This also simplifies the get_symcache() method by adding some return-early sections allowing us to dedent the code and reduce the complexity.