### PR TITLE
Add --no-deps to pip install arguments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ COPY requirements.txt /tmp/
 WORKDIR /tmp
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir --no-deps -r requirements.txt && \
     pip check --disable-pip-version-check
 
 COPY . /app


### PR DESCRIPTION
This restricts pip to only installing what's listed in `requirements.txt` file.