### PR TITLE
Rebuild requirments file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -271,7 +271,9 @@ markupsafe==2.1.1 \
 markus[datadog]==4.2.0 \
     --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \
     --hash=sha256:9dd41ce53b25a3e806b0d065808fec00c4ec945e80cf5a72431bf9b61b44d7fb
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   markus
 milksnake==0.1.5 \
     --hash=sha256:550ca1fc4222724149ee5a933e6bb8347630c0ed023a2a97701ab94fa256f6b4 \
     --hash=sha256:dfcd43b78bcf93897a75eea1dadf71c848319f19451cff4f3f3a628a5abe1688


### PR DESCRIPTION
pip had a 23.3 release on october 15th which changed how dependency resolution works with extras. https://pip.pypa.io/en/stable/news/

This PR rebuilds the requirements so CI pases again.