### PR TITLE
Add GitHub Actions workflow to build, test and push Docker images.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,95 @@
+name: Build, test and push a Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get info
+        run: |
+          uname -v
+          docker info
+      - name: Create version.json
+        run: |
+          # create a version.json per
+          # https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
+      - name: Output version.json
+        run: cat version.json
+      - name: Build Docker images
+        run: make build
+      - name: Verify requirements.txt contains correct dependencies
+        run: |
+          docker compose run --rm --no-deps test-ci bash ./bin/run_verify_reqs.sh
+      - name: Run lint check
+        run: |
+          make .env
+          docker compose run --rm --no-deps test-ci bash ./bin/run_lint.sh
+      - name: Run Eliot tests
+        run: |
+          docker compose up -d fakesentry statsd
+          docker compose run --rm test-ci bash ./bin/run_test.sh eliot
+      - name: Build docs
+        run: |
+          docker compose run --rm --no-deps test-ci bash make -C docs/ html
+      - name: Save Docker image to file
+        run: |
+          docker save -o eliot-image.tar eliot:build
+      - name: Persist Docker image
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-image
+          path: eliot-image.tar
+          retention-days: 7
+
+  push:
+    needs: build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    environment: build
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: artifact-writer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v1
+      - name: Load Docker image tarball from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image
+      - name: Load tarball to Docker Image
+        run: |
+          docker load -i eliot-image.tar
+      - name: Set Docker image tag to "latest"
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "DOCKER_IMAGE_TAG=latest" >> "$GITHUB_ENV"
+      - name: Set Docker image tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "DOCKER_IMAGE_TAG=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+      - name: Tag and push Docker image
+        run: |
+          gcloud --quiet auth configure-docker us-docker.pkg.dev
+          docker tag eliot:build "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
+          docker push "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
+        env:
+          DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   build:
+    environment: build
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,50 +50,21 @@ jobs:
       - name: Build docs
         run: |
           docker compose run --rm --no-deps test-ci bash make -C docs/ html
-      - name: Save Docker image to file
-        run: |
-          docker save -o eliot-image.tar eliot:build
-      - name: Persist Docker image
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-image
-          path: eliot-image.tar
-          retention-days: 7
 
-  push:
-    needs: build
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-    environment: build
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: artifact-writer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-      - uses: google-github-actions/setup-gcloud@v1
-      - name: Load Docker image tarball from build job
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-image
-      - name: Load tarball to Docker Image
-        run: |
-          docker load -i eliot-image.tar
-      - name: Set Docker image tag to "latest"
+      - name: Set Docker image tag to "latest" for updates of the main branch
         if: github.ref == 'refs/heads/main'
         run: |
-          echo "DOCKER_IMAGE_TAG=latest" >> "$GITHUB_ENV"
-      - name: Set Docker image tag
+          echo "IMAGE_TAG=latest" >> "$GITHUB_ENV"
+      - name: Set Docker image tag to the git tag for tagged builds
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "DOCKER_IMAGE_TAG=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
-      - name: Tag and push Docker image
-        run: |
-          gcloud --quiet auth configure-docker us-docker.pkg.dev
-          docker tag eliot:build "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
-          docker push "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
-        env:
-          DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
+          echo "IMAGE_TAG=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+      - name: Push the Docker image to GAR
+        if: env.IMAGE_TAG != ''
+        uses: mozilla-it/deploy-actions/docker-push@main
+        with:
+          local_image: eliot:build
+          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          workload_identity_pool_project_number: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
This is a first fully working GitHub Actions workflow to build, test and upload Docker images for Eliot.

The workflow is triggered when a pull request against the main branch is opened, updated or merged, or when a new tag is created.

The workflow consists of two jobs. The `build` job builds, tests and stores an image as an GitHub Actions artifact. This job is always run. The `push` job is only run when the `main` branch is updated (pushing the `latest` tag) or when a new tag has been created (using the tag as the Docker image tag).

I [tested this workflow on a private fork of Eliot](https://github.com/mozilla-sre-deploy/smarnach-eliot-test/actions/runs/6788079337). I temporarily gave that fork permission to push to the Eliot GAR repository in the new GCP project. The workflow appears to work fine, and does not leak any GCP project ids in case we want to avoid that.

We could avoid uploading and downloading the Docker image if we would merge the two jobs into a single one. However, this would have the following downsides:

* The `push` job has access to the "secrets". While none of the secrets are particularly sensitive, we still don't want to make them available to fork builds. The `build` job does not have access to any sensitive information, and we could run it on fork PRs.

* We would need to repeat the `if` condition for the `push` job for every single step if we merge the workflows. We could work around this problem by factoring this job out into a reusable action (which we probably want to do anyway, see below).

Problems with the current approach:

* Artifact storage to store Docker images is slow and feels artificial. It may also be subject to race conditions, since concurrent workflows could overwrite the Docker image before it is used by the `push` job. We could look into using GitHub Packages to store the Docker image, but that doesn't support any retention policies as far as I can tell, so we'd need to come up with an automated clean-up mechanism. 

* The `push` job should be made generic, so we (and others) can use it in other repositories.

Overall, I'm leaning towards factoring out the `push` job into a reusable action and then merging the two jobs into a single one.