### PR TITLE
Set SHELL env variable in local development containers to bash.

### DIFF
--- a/docker/config/local_dev.env
+++ b/docker/config/local_dev.env
@@ -16,3 +16,7 @@ ELIOT_STATSD_NAMESPACE=mcboatface
 ELIOT_STATSD_PORT=8125
 ELIOT_SYMBOLS_CACHE_MAX_SIZE=4gb
 ELIOT_SECRET_SENTRY_DSN=http://public@fakesentry:8090/1
+
+# This makes the shell inside a dev container in VS Code work.
+# The shell for the app user otherwise defaults to /sbin/nologin.
+SHELL=/bin/bash


### PR DESCRIPTION
This change makes the shell inside dev containers in VS Code work. We already made [the same change for Tecken](https://github.com/mozilla-services/tecken/pull/2833).