### PR TITLE
Don't use the 'build' GitHub env for CI builds.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   build:
-    environment: build
     permissions:
       contents: read
       deployments: write
@@ -67,7 +66,7 @@ jobs:
           echo DEPLOYMENT_ENV=prod >> "$GITHUB_ENV"
       - name: Push the Docker image to GAR
         if: env.IMAGE_TAG != ''
-        uses: mozilla-it/deploy-actions/docker-push@main
+        uses: mozilla-it/deploy-actions/docker-push@v3.9.0
         with:
           local_image: eliot:build
           image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}


### PR DESCRIPTION
This makes use of the more lenient permissions applied https://github.com/mozilla-it/webservices-infra/pull/1356 to avoid using the `build` environment for CI builds, because [using that environment causes unnecessary noise in the GitHub web UI on PR pages](https://github.com/mozilla-it/webservices-infra/pull/1331).