### PR TITLE
Revert "Don't use the 'build' GitHub env for CI builds."

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    environment: build
     permissions:
       contents: read
       deployments: write
@@ -66,7 +67,7 @@ jobs:
           echo DEPLOYMENT_ENV=prod >> "$GITHUB_ENV"
       - name: Push the Docker image to GAR
         if: env.IMAGE_TAG != ''
-        uses: mozilla-it/deploy-actions/docker-push@v3.9.0
+        uses: mozilla-it/deploy-actions/docker-push@main
         with:
           local_image: eliot:build
           image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}


### PR DESCRIPTION
Reverts mozilla-services/eliot#111

Unfortunately, this broke workload identity federation. I must have made a mistake in my tests. I'm rolling this back to make builds work again.