### PR TITLE
Make ports exposed in docker compose configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     extends:
       service: base
     ports:
-      - "8000:8000"
+      - "${EXPOSE_ELIOT_PORT:-8000}:8000"
     depends_on:
       - fakesentry
       - statsd
@@ -55,15 +55,11 @@ services:
       context: docker/images/fakesentry
     image: local/eliot_fakesentry
     ports:
-      - "8090:8090"
+      - "${EXPOSE_SENTRY_PORT:-8090}:8090"
     command: run --host 0.0.0.0 --port 8090
 
   # https://hub.docker.com/r/hopsoft/graphite-statsd/
   statsd:
     image: hopsoft/graphite-statsd:latest
     ports:
-      - "8081:80"
-      - "2003-2004:2003-2004"
-      - "2023-2024:2023-2024"
-      - "8125:8125/udp"
-      - "8126:8126"
+      - "${EXPOSE_STATSD_PORT:-8081}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,4 +62,4 @@ services:
   statsd:
     image: hopsoft/graphite-statsd:latest
     ports:
-      - "${EXPOSE_STATSD_PORT:-8081}:80"
+      - "${EXPOSE_GRAFANA_PORT:-8081}:80"


### PR DESCRIPTION
~docker-compose is exposing ports on the host that I believe are only needed internally within the docker-compose network.~

~This caused me issues with trying to use a vscode devcontainer, as seen in https://github.com/mozilla-services/tecken/pull/2857, because both projects expose these ports, and the environments are not automatically shut down when vscode is closed: https://github.com/mozilla-services/tecken/pull/2857/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R10~

~It would make sense to also do this in tecken, but that exposes more ports that I am less sure are unnecessary~

see also https://github.com/mozilla-services/tecken/pull/2858

per https://github.com/mozilla-services/tecken/pull/2857/files#r1430382049

     "shutdownAction": "none",

    [biancadanforth](https://github.com/biancadanforth) [Dec 18, 2023](https://github.com/mozilla-services/tecken/pull/2857/files#r1430382049):
    This is what prevents the devcontainer from shutting down when we close out of VS Code IIUC.

with devcontainer and its docker-compose dependencies running even when vscode isn't open, ports conflict between tecken, eliot, and socorro, so this PR makes the exposed ports configurable via environment variables, which can be set in .env in each project to avoid overlap.