### PR TITLE
bug-1880156: explicitly attach to primary services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ build: .env  ## | Build docker images.
 
 .PHONY: run
 run: .env .docker-build  ## | Run eliot and services.
-	${DC} up eliot fakesentry
+	${DC} up \
+		--attach eliot \
+		--attach fakesentry \
+		eliot fakesentry
 
 .PHONY: devcontainerbuild
 devcontainerbuild: .env .docker-build .devcontainer-build  ## | Build VS Code development container.


### PR DESCRIPTION
This prevents docker from attaching to backing services which have a lot of output and make the console hard to follow.

To test:

1. `docker compose stop`
2. `make build`
3. `make run`