### PR TITLE
obs-98: update release configuration to require deploy bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ main_branch = "main"
 [tool.release]
 github_user = "mozilla-services"
 github_project = "eliot"
-# bugzilla_product = "Eliot"
-# bugzilla_component = "General"
+bugzilla_product = "Eliot"
+bugzilla_component = "General"
 main_branch = "main"
 tag_name_template = "v%Y.%m.%d"
 


### PR DESCRIPTION
This brings Eliot in line with other services.

We can compare with other services. For example, here's Socorro configuration:

https://github.com/mozilla-services/socorro/blob/9a7022e2382818df524d29bafd745bd62c096604/pyproject.toml#L25-L31

Unfortunately, there's no way to test this in a PR.