### PR TITLE
Update fillmore, sentry-sdk, and kent

### DIFF
--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -17,7 +17,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN pip install -U 'pip>=20' && \
-    pip install --no-cache-dir 'kent==1.2.0'
+    pip install --no-cache-dir 'kent==2.0.0'
 
 USER kent
 

--- a/eliot/app.py
+++ b/eliot/app.py
@@ -253,7 +253,7 @@ class EliotApp(falcon.App):
         """
         # NOTE(willkg): we might be able to get rid of the sentry event capture if the
         # FalconIntegration in sentry-sdk gets fixed
-        with sentry_sdk.configure_scope() as scope:
+        with sentry_sdk.new_scope() as scope:
             # The SentryWsgiMiddleware tacks on an unhelpful transaction value which
             # makes things hard to find in the Sentry interface, so we stomp on that
             # with the req.path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.pytest.ini_options]
 norecursedirs = [".cache", "__pycache__"]
 testpaths = "tests/"
-addopts = "-rsxX --showlocals --tb=native -p no:cacheprovider --import-mode=importlib"
+addopts = "-rsxX --showlocals --tb=native -p no:cacheprovider"
 
 # Transform all warnings into errors
 filterwarnings = [

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ datadog==0.49.1
 dockerflow==2024.4.2
 everett==3.3.0
 falcon==3.1.3
-fillmore==1.2.0
+fillmore==2.0.0
 gunicorn==22.0.0
 honcho==1.1.0
 inotify_simple==1.3.5
@@ -17,7 +17,7 @@ pytest==8.2.1
 requests==2.32.3
 requests-mock==1.12.1
 ruff==0.4.7
-sentry-sdk==1.45.0
+sentry-sdk==2.5.1
 Sphinx==7.3.7
 sphinxcontrib-httpdomain==1.8.1
 sphinx-rtd-theme==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,9 +154,9 @@ falcon==3.1.3 \
     --hash=sha256:e19a0a3827821bcf754a9b24217e3b8b4750f7eb437c4a8c461135a86ca9b1c5 \
     --hash=sha256:e1f622d73111912021b8311d1e5d1eabef484217d2d30abe3d237533cb225ce9
     # via -r requirements.in
-fillmore==1.2.0 \
-    --hash=sha256:1968a2ba5adc17ebef362df51ec958c3d78427a77d2218a2709aabc3598eeceb \
-    --hash=sha256:c95f7172614c256fe162e93ae6d5beb07e45e1fe7f71b94f5a08eab45dc58a40
+fillmore==2.0.0 \
+    --hash=sha256:840901d80799ce50db49c3e377815424a356c3e81c6cea5111684c58113d7ad1 \
+    --hash=sha256:fd1a2c2e829073cef3d49f032033d78dbee48f377eb4b915f29084e76f6facb4
     # via -r requirements.in
 gunicorn==22.0.0 \
     --hash=sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9 \
@@ -481,9 +481,9 @@ ruff==0.4.7 \
     --hash=sha256:fa4dafe3fe66d90e2e2b63fa1591dd6e3f090ca2128daa0be33db894e6c18648 \
     --hash=sha256:fa9773c6c00f4958f73b317bc0fd125295110c3776089f6ef318f4b775f0abe4
     # via -r requirements.in
-sentry-sdk==1.45.0 \
-    --hash=sha256:1ce29e30240cc289a027011103a8c83885b15ef2f316a60bcc7c5300afa144f1 \
-    --hash=sha256:509aa9678c0512344ca886281766c2e538682f8acfa50fd8d405f8c417ad0625
+sentry-sdk==2.5.1 \
+    --hash=sha256:1f87acdce4a43a523ae5aa21a3fc37522d73ebd9ec04b1dbf01aa3d173852def \
+    --hash=sha256:fbc40a78a8a9c6675133031116144f0d0940376fa6e4e1acd5624c90b0aaf58b
     # via
     #   -r requirements.in
     #   fillmore

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import ANY
 
-from fillmore.test import diff_event
+from fillmore.test import diff_structure
 from markus.testing import MetricsMock
 from werkzeug.test import Client
 
@@ -154,12 +154,12 @@ def test_sentry_scrubbing(sentry_helper):
         )
         assert resp.status_code == 500
 
-        (event,) = sentry_client.events
+        (event,) = sentry_client.envelope_payloads
 
         # Drop the "_meta" bit because we don't want to compare that.
         del event["_meta"]
 
-        differences = diff_event(event, BROKEN_EVENT)
+        differences = diff_structure(event, BROKEN_EVENT)
         assert differences == []
 
 


### PR DESCRIPTION
sentry-sdk 2 reworked a bunch of api internals and switched from submitting event data to `/store` to submitting it to `/envelope` in the envelope format.

That required changes in kent and fillmore to support.

This updates kent, fillmore, and sentry-sdk to latest versions.

To review:

1. run tests
2. run eliot and go to `http://localhost:8000/__broken__` which triggers an unhandled exception
3. go to `http://localhost:8090/` and view the event