### PR TITLE
OBS-198: Add workflow to manually trigger a deployment.

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,0 +1,39 @@
+name: Manually trigger a deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: The Docker image tag to deploy
+        type: string
+        default: latest
+        required: true
+      ref:
+        description: The Git ref to deploy
+        type: string
+        default: refs/heads/main
+        required: true
+      environment:
+        description: The environment to deploy to
+        type: choice
+        default: stage
+        required: true
+        options:
+          - stage
+          - prod
+
+jobs:
+  build:
+    permissions:
+      deployments: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create GitHub deployment
+      run: |
+        gh api "repos/${{ github.repository }}/deployments" \
+            -f environment="${{ inputs.environment }}" \
+            -f ref="${{ inputs.ref }}" \
+            -F required_contexts[] \
+            -F payload[image_tag]="${{ inputs.image_tag }}"
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Due to the way Four Keys collects metrics, we now need to trigger all deployments by creating a GitHub deployment on the application repo. The `workdlow_dispatch` trigger on the deployment repo now always expects an event payload as input and should no longer be triggered manually. This workflow provides the new way to conveniently trigger a manual deployment.