### PR TITLE
Disable the auto-merge feature for manual deployments.

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -33,6 +33,7 @@ jobs:
         gh api "repos/${{ github.repository }}/deployments" \
             -f environment="${{ inputs.environment }}" \
             -f ref="${{ inputs.ref }}" \
+            -F auto_merge=false \
             -F required_contexts[] \
             -F payload[image_tag]="${{ inputs.image_tag }}"
       env:


### PR DESCRIPTION
I never understood what exactly GitHub's bizarre auto-merge feature for deployments does, but unfortunately it's enabled by default, and I somtimes forget disabling it. The feature has never been helpful for me, though most of the time it doesn't hurt either. However, I just [ran into a case where it _did_ hurt](https://github.com/mozilla-services/eliot/actions/runs/10612872839/job/29415484841), so let's disable it for good.