### PR TITLE
bug-1918203: remove use of sentry_sdk.Hub in favor of scope apis

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ PyYAML==6.0.2
 requests==2.32.3
 requests-mock==1.12.1
 ruff==0.9.7
-sentry-sdk==2.7.1
+sentry-sdk==2.22.0
 Sphinx==8.2.1
 sphinxcontrib-httpdomain==1.8.1
 sphinx-rtd-theme==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -774,9 +774,9 @@ ruff==0.9.7 \
     --hash=sha256:e9ece95b7de5923cbf38893f066ed2872be2f2f477ba94f826c8defdd6ec6b7d \
     --hash=sha256:f313b5800483770bd540cddac7c90fc46f895f427b7820f18fe1822697f1fec9
     # via -r requirements.in
-sentry-sdk==2.7.1 \
-    --hash=sha256:25006c7e68b75aaa5e6b9c6a420ece22e8d7daec4b7a906ffd3a8607b67c037b \
-    --hash=sha256:ef1b3d54eb715825657cd4bb3cb42bb4dc85087bac14c56b0fd8c21abd968c9a
+sentry-sdk==2.22.0 \
+    --hash=sha256:3d791d631a6c97aad4da7074081a57073126c69487560c6f8bffcf586461de66 \
+    --hash=sha256:b4bf43bb38f547c84b2eadcefbe389b36ef75f3f38253d7a74d6b928c07ae944
     # via
     #   -r requirements.in
     #   fillmore

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -570,9 +570,6 @@ def test_sentry_scrubbing(sentry_helper, cm_client, monkeypatch, tmpdir):
 
         (event,) = sentry_client.envelope_payloads
 
-    # Drop the "_meta" bit because we don't want to compare that.
-    del event["_meta"]
-
     differences = diff_structure(event, BROKEN_EVENT)
     assert differences == []
 


### PR DESCRIPTION
because it's deprecated

and bump sentry-sdk from 2.7.1 to 2.22.0 