### PR TITLE
OBS-361: Remove tini from Docker containers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
         groupid: ${USE_GID:-10001}
     image: eliot-devcontainer
     entrypoint: ["sleep", "inf"]
+    stop_signal: SIGKILL  # Doesn't seem to respond to anything else
 
   # https://github.com/willkg/kent
   fakesentry:
@@ -71,6 +72,7 @@ services:
     ports:
       - "${EXPOSE_SENTRY_PORT:-8090}:8090"
     command: run --host 0.0.0.0 --port 8090
+    stop_signal: SIGINT
 
   # https://hub.docker.com/r/hopsoft/graphite-statsd/
   statsd:

--- a/docker/images/fakesentry/Dockerfile
+++ b/docker/images/fakesentry/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/
 RUN groupadd -r kent && useradd --no-log-init -r -g kent kent
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl tini && \
+    apt-get install -y --no-install-recommends curl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -21,5 +21,5 @@ RUN pip install -U 'pip>=20' && \
 
 USER kent
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/kent-server"]
+ENTRYPOINT ["/usr/local/bin/kent-server"]
 CMD ["run"]


### PR DESCRIPTION
The tini process was originally added to make Docker comtainers quite properly when receiving the TERM signal on `docker compose stop`. Some containers don't react to this signal, so terminating them will hang for ten seconds before Docker Compose sends SIGKILL.

This change removes tini from the fakesentry container. I added apprioriate `stop_signal` directives to docker-compose.yml.

https://mozilla-hub.atlassian.net/browse/OBS-361