### PR TITLE
Fix dependabot updates for docker/images/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directories:
+      - "/docker"
+      - "/docker/images/fakesentry"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "/docker"
-      - "/docker/images/fakesentry"
+      - "/docker/images/*"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
switches from directory to directories, as documented here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories

directories explicitly supports wildcards