### PR TITLE
bug-1954518: Allow tildes in debug filename

### DIFF
--- a/eliot/symbolicate_resource.py
+++ b/eliot/symbolicate_resource.py
@@ -113,7 +113,7 @@ VALID_DEBUG_ID = re.compile(r"^([A-Fa-f0-9]*)$")
 
 # A valid debug filename consists of zero or more alpha-numeric characters, some
 # punctuation, and spaces.
-VALID_DEBUG_FILENAME = re.compile(r"^([A-Za-z0-9_.+{}@<> -]*)$")
+VALID_DEBUG_FILENAME = re.compile(r"^([A-Za-z0-9_.+{}@<> ~-]*)$")
 
 # Maximum number of symbolication jobs to do in a single request
 MAX_JOBS = 10

--- a/tests/test_symbolicate_resource.py
+++ b/tests/test_symbolicate_resource.py
@@ -97,6 +97,7 @@ FUNC 1260 4a 0 LdrpReadMemory
                 "000000000000000000000000000000000",
             ],
             ["Font Awesome 5 Free-Solid-900.otf", "000000000000000000000000000000000"],
+            ["libgallium-24.2.8-1~bpo12+rpt1.so", "686E9835D66E381253D84E5E01FEFAD30"],
         ],
     ],
     ids=counter(),


### PR DESCRIPTION
In Debian package versions, tildes can be used to affect sorting behaviour.  This is used for backported packages (e.g. `bpo~12`), of which there are a lot in Raspberry Pi OS, for example `libgallium-24.2.8-1~bpo12+rpt1.so`.